### PR TITLE
Declaring usage() as static function

### DIFF
--- a/allow_eecode/pi.allow_eecode.php
+++ b/allow_eecode/pi.allow_eecode.php
@@ -114,7 +114,7 @@ class Allow_eecode {
 	 * @access	public
 	 * @return	string
 	 */
-	function usage()
+	static function usage()
 	{
 
 		ob_start(); 


### PR DESCRIPTION
To resolve this warning:

```
A PHP Error was encountered

Severity: 8192

Message: Non-static method Allow_eecode::usage() should not be called statically, assuming $this from incompatible context

Filename: allow_eecode/pi.allow_eecode.php

Line Number: 34
```
